### PR TITLE
Potential fix for code scanning alert no. 28: Server-side request forgery

### DIFF
--- a/src/app/api/documents/proxy/route.ts
+++ b/src/app/api/documents/proxy/route.ts
@@ -17,13 +17,6 @@ export async function GET(request: NextRequest) {
     return NextResponse.json({ error: 'URL is required' }, { status: 400 })
   }
 
-  let parsedUrl: URL
-  try {
-    parsedUrl = new URL(url)
-  } catch {
-    return NextResponse.json({ error: 'Invalid URL format' }, { status: 400 })
-  }
-
   const allowedHost = process.env.AZURE_STORAGE_PROXY_HOST
   if (!allowedHost) {
     console.error('AZURE_STORAGE_PROXY_HOST is not configured')
@@ -33,13 +26,32 @@ export async function GET(request: NextRequest) {
     )
   }
 
+  let parsedUrl: URL
+  try {
+    parsedUrl = new URL(url)
+  } catch {
+    return NextResponse.json({ error: 'Invalid URL format' }, { status: 400 })
+  }
+
   if (parsedUrl.hostname !== allowedHost || parsedUrl.protocol !== 'https:') {
     return NextResponse.json({ error: 'Invalid document URL' }, { status: 400 })
   }
 
+  const decodedPath = decodeURIComponent(parsedUrl.pathname)
+  if (
+    decodedPath.includes('..') ||
+    decodedPath.includes('\\') ||
+    !decodedPath.startsWith('/')
+  ) {
+    return NextResponse.json({ error: 'Invalid document URL' }, { status: 400 })
+  }
+
+  const trustedBaseUrl = new URL(`https://${allowedHost}`)
+  const targetUrl = new URL(decodedPath + parsedUrl.search, trustedBaseUrl)
+
   try {
     // Fetch the document from Azure Storage
-    const response = await fetch(parsedUrl.toString())
+    const response = await fetch(targetUrl.toString())
 
     if (!response.ok) {
       // Log the view activity
@@ -47,7 +59,7 @@ export async function GET(request: NextRequest) {
         await logActivity({
           userId: session.user.id,
           userName: session.user.name ?? session.user.email ?? 'Unknown user',
-          fileName: parsedUrl.pathname.split('/').pop() ?? 'Unknown file',
+          fileName: targetUrl.pathname.split('/').pop() ?? 'Unknown file',
           activityType: ActivityType.VIEW,
           ipAddress:
             request.headers.get('x-forwarded-for') ??

--- a/src/app/api/documents/proxy/route.ts
+++ b/src/app/api/documents/proxy/route.ts
@@ -17,9 +17,29 @@ export async function GET(request: NextRequest) {
     return NextResponse.json({ error: 'URL is required' }, { status: 400 })
   }
 
+  let parsedUrl: URL
+  try {
+    parsedUrl = new URL(url)
+  } catch {
+    return NextResponse.json({ error: 'Invalid URL format' }, { status: 400 })
+  }
+
+  const allowedHost = process.env.AZURE_STORAGE_PROXY_HOST
+  if (!allowedHost) {
+    console.error('AZURE_STORAGE_PROXY_HOST is not configured')
+    return NextResponse.json(
+      { error: 'Document proxy is not properly configured' },
+      { status: 500 }
+    )
+  }
+
+  if (parsedUrl.hostname !== allowedHost || parsedUrl.protocol !== 'https:') {
+    return NextResponse.json({ error: 'Invalid document URL' }, { status: 400 })
+  }
+
   try {
     // Fetch the document from Azure Storage
-    const response = await fetch(url)
+    const response = await fetch(parsedUrl.toString())
 
     if (!response.ok) {
       // Log the view activity
@@ -27,7 +47,7 @@ export async function GET(request: NextRequest) {
         await logActivity({
           userId: session.user.id,
           userName: session.user.name ?? session.user.email ?? 'Unknown user',
-          fileName: new URL(url).pathname.split('/').pop() ?? 'Unknown file',
+          fileName: parsedUrl.pathname.split('/').pop() ?? 'Unknown file',
           activityType: ActivityType.VIEW,
           ipAddress:
             request.headers.get('x-forwarded-for') ??

--- a/src/app/api/documents/proxy/route.ts
+++ b/src/app/api/documents/proxy/route.ts
@@ -26,18 +26,33 @@ export async function GET(request: NextRequest) {
     )
   }
 
-  let parsedUrl: URL
+  let requestedPathWithQuery: string
   try {
-    parsedUrl = new URL(url)
+    // Backward compatibility: if a full URL is provided, only allow the configured host.
+    if (url.startsWith('http://') || url.startsWith('https://')) {
+      const parsedUrl = new URL(url)
+      if (parsedUrl.protocol !== 'https:' || parsedUrl.hostname !== allowedHost) {
+        return NextResponse.json({ error: 'Invalid document URL' }, { status: 400 })
+      }
+      if (parsedUrl.username || parsedUrl.password) {
+        return NextResponse.json({ error: 'Invalid document URL' }, { status: 400 })
+      }
+      requestedPathWithQuery = `${parsedUrl.pathname}${parsedUrl.search}`
+    } else {
+      // Preferred mode: relative path/query only.
+      if (!url.startsWith('/')) {
+        return NextResponse.json({ error: 'Invalid document URL' }, { status: 400 })
+      }
+      requestedPathWithQuery = url
+    }
   } catch {
     return NextResponse.json({ error: 'Invalid URL format' }, { status: 400 })
   }
 
-  if (parsedUrl.hostname !== allowedHost || parsedUrl.protocol !== 'https:') {
-    return NextResponse.json({ error: 'Invalid document URL' }, { status: 400 })
-  }
+  const trustedBaseUrl = new URL(`https://${allowedHost}`)
+  const targetUrl = new URL(requestedPathWithQuery, trustedBaseUrl)
 
-  const decodedPath = decodeURIComponent(parsedUrl.pathname)
+  const decodedPath = decodeURIComponent(targetUrl.pathname)
   if (
     decodedPath.includes('..') ||
     decodedPath.includes('\\') ||
@@ -45,9 +60,6 @@ export async function GET(request: NextRequest) {
   ) {
     return NextResponse.json({ error: 'Invalid document URL' }, { status: 400 })
   }
-
-  const trustedBaseUrl = new URL(`https://${allowedHost}`)
-  const targetUrl = new URL(decodedPath + parsedUrl.search, trustedBaseUrl)
 
   try {
     // Fetch the document from Azure Storage


### PR DESCRIPTION
Potential fix for [https://github.com/alandavidhenry/document-portal-next-azure/security/code-scanning/28](https://github.com/alandavidhenry/document-portal-next-azure/security/code-scanning/28)

In general, to fix this class of SSRF problems you must ensure user input cannot arbitrarily choose the destination host/protocol of an outgoing request. Common strategies are: (1) use an allow‑list of hosts or base URLs and let user input influence only a bounded path or resource identifier; (2) strictly validate and normalize the URL, rejecting private IPs, non-HTTP(S) schemes, or unexpected hosts; or (3) avoid proxying arbitrary URLs at all and instead map user input to internal identifiers.

For this specific endpoint, the minimal fix without changing intended behavior is to parse the user-provided `url` into a `URL` object, then enforce that it points to the expected Azure Storage account/host (or at least to an allow‑listed set of hosts) and uses `http`/`https`. If the URL fails validation, return a 400 error. We should then use the validated `URL` string when calling `fetch` and when deriving the `fileName`. Since the file mentions Azure Storage, a reasonable and non-invasive approach is to add an environment-based allow‑list such as `process.env.AZURE_STORAGE_PROXY_HOST` (e.g. `myaccount.blob.core.windows.net`), compare the parsed URL’s `hostname` (and optionally `protocol`) against this, and reject anything else. This keeps current functionality (proxying Azure documents) but blocks requests to internal or arbitrary external services.

Concretely in `src/app/api/documents/proxy/route.ts`:

- After retrieving `url`, attempt `new URL(url)` in a `try` block to both validate the syntax and inspect its components.
- Read an allow‑listed host (or hosts) from environment variables (e.g. `process.env.AZURE_STORAGE_PROXY_HOST`) and compare `parsedUrl.hostname` to it. If it does not match, respond with `400` “Invalid document URL”.
- Optionally, enforce `parsedUrl.protocol === 'https:'` (or `http:`/`https:`).
- Use `parsedUrl.toString()` for `fetch` instead of the raw `url`, and reuse `parsedUrl` when computing `fileName`, eliminating duplicate parsing and ensuring we only work with a validated URL.
- Keep all existing logging and behavior otherwise unchanged.

No new imports are strictly required; `URL` and `process.env` are available in the runtime.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
